### PR TITLE
Add loop index

### DIFF
--- a/minijanus.js
+++ b/minijanus.js
@@ -11,8 +11,8 @@ function JanusPluginHandle(session) {
 }
 
 /** Attaches this handle to the Janus server and sets its ID. **/
-JanusPluginHandle.prototype.attach = function(plugin) {
-  var payload = { plugin: plugin, "force-bundle": true, "force-rtcp-mux": true };
+JanusPluginHandle.prototype.attach = function(plugin, loop_index) {
+  var payload = { plugin: plugin, loop_index, "force-bundle": true, "force-rtcp-mux": true };
   return this.session.send("attach", payload).then(resp => {
     this.id = resp.data.id;
     return resp;

--- a/minijanus.js
+++ b/minijanus.js
@@ -12,7 +12,7 @@ function JanusPluginHandle(session) {
 
 /** Attaches this handle to the Janus server and sets its ID. **/
 JanusPluginHandle.prototype.attach = function(plugin, loop_index) {
-  var payload = { plugin: plugin, loop_index, "force-bundle": true, "force-rtcp-mux": true };
+  var payload = { plugin: plugin, loop_index: loop_index, "force-bundle": true, "force-rtcp-mux": true };
   return this.session.send("attach", payload).then(resp => {
     this.id = resp.data.id;
     return resp;


### PR DESCRIPTION
Geplant wäre, dass naf-janus-adapter dann den loop_index übergibt und sich minijanus darüber nicht kümmern muss sondern einfach weiter gibt